### PR TITLE
6047: added feature mssqlserver / tsql adapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ dbt-col-lineage --select stg_orders --format text
 - `--format`, `-f`: Output format for static analysis (`text` or `dot`). Not used with `--explore`. (default: `text`)
 - `--output`, `-o`: Output filename for `dot` format (without extension, default: `lineage`). Not used with `--explore`.
 - `--port`, `-p`: Port for the interactive web server when using `--explore` (default: `8000`).
+- `--adapter`: Override the SQL dialect used by the parser (sqlglot dialect name, e.g., `tsql`, `snowflake`, `bigquery`). When provided, this overrides the adapter detected from the dbt manifest.
 
 ## Limitations
 - Doesn't support python models
@@ -94,6 +95,7 @@ The tool has been tested with the following dbt adapters:
 - Snowflake
 - SQLite
 - DuckDB
+- MS SQLServer / TSQL
 
 
 ## License

--- a/dbt_column_lineage/artifacts/adapter_mapping.py
+++ b/dbt_column_lineage/artifacts/adapter_mapping.py
@@ -1,0 +1,28 @@
+"""
+Centralized adapter/dialect normalization for dbt-column-lineage.
+
+This module defines a single source of truth for mapping raw dbt adapter
+names to sqlglot dialect names. For example, dbt may report the adapter
+"sqlserver" while sqlglot expects the dialect name "tsql".
+
+Extend ADAPTER_TO_DIALECT as needed to support additional adapters.
+"""
+from typing import Dict, Optional
+
+# Mapping from dbt adapter name (metadata.adapter_type) to sqlglot dialect
+ADAPTER_TO_DIALECT: Dict[str, str] = {
+    # dbt-sqlserver adapter reports "sqlserver"; sqlglot uses "tsql"
+    "sqlserver": "tsql",
+}
+
+
+def normalize_adapter(adapter_name: Optional[str]) -> Optional[str]:
+    """Normalize a dbt adapter name to a sqlglot dialect name.
+
+    If adapter_name is None or empty, returns it unchanged.
+    If there is no mapping defined, returns the original adapter_name.
+    """
+    if not adapter_name:
+        return adapter_name
+    lower = adapter_name.lower()
+    return ADAPTER_TO_DIALECT.get(lower, lower)

--- a/dbt_column_lineage/artifacts/manifest.py
+++ b/dbt_column_lineage/artifacts/manifest.py
@@ -2,6 +2,8 @@ import json
 from typing import Dict, Optional, Set, Any
 from pathlib import Path
 
+from dbt_column_lineage.artifacts.adapter_mapping import normalize_adapter
+
 
 class ManifestReader:
     def __init__(self, manifest_path: Optional[str] = None):
@@ -14,8 +16,11 @@ class ManifestReader:
         with open(self.manifest_path, "r") as f:
             self.manifest = json.load(f)
             
-    def get_adapter(self) -> str:
-        return self.manifest.get("metadata", {}).get("adapter_type")
+    def get_adapter(self) -> Optional[str]:
+        adapter_name = self.manifest.get("metadata", {}).get("adapter_type")
+        return normalize_adapter(adapter_name)
+
+
 
     def _find_node(self, model_name: str) -> Optional[Dict[str, Any]]:
         """Find a node in the manifest by model name."""

--- a/dbt_column_lineage/cli/main.py
+++ b/dbt_column_lineage/cli/main.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import click
 import logging
+from typing import Optional
 
 from dbt_column_lineage.lineage.display import TextDisplay, DotDisplay
 from dbt_column_lineage.lineage.display.html.explore import LineageExplorer
@@ -49,7 +50,9 @@ logging.basicConfig(
 @click.option('--port', '-p', 
               default=8000,
               help='Port to run the HTML server (only used with --explore)')
-def cli(select: str, explore: bool, catalog: str, manifest: str, format: str, output: str, port: int) -> None:
+@click.option('--adapter',
+              help='Override sqlglot dialect (e.g., tsql, snowflake, bigquery). If set, ignores adapter from manifest.')
+def cli(select: str, explore: bool, catalog: str, manifest: str, format: str, output: str, port: int, adapter: Optional[str]) -> None:
     """DBT Column Lineage - Generate column-level lineage for DBT models."""
     if not select and not explore:
         click.echo("Error: Either --select or --explore must be specified", err=True)
@@ -60,7 +63,7 @@ def cli(select: str, explore: bool, catalog: str, manifest: str, format: str, ou
         sys.exit(1)
 
     try:
-        service = LineageService(Path(catalog), Path(manifest))
+        service = LineageService(Path(catalog), Path(manifest), adapter=adapter)
         
         if explore:
             click.echo(f"Starting explore mode server on port {port}...")

--- a/dbt_column_lineage/lineage/service.py
+++ b/dbt_column_lineage/lineage/service.py
@@ -34,8 +34,8 @@ class LineageSelector:
 class LineageService:
     """Service for handling lineage operations."""
     
-    def __init__(self, catalog_path: Path, manifest_path: Path):
-        self.registry = ModelRegistry(str(catalog_path), str(manifest_path))
+    def __init__(self, catalog_path: Path, manifest_path: Path, adapter: Optional[str] = None):
+        self.registry = ModelRegistry(str(catalog_path), str(manifest_path), adapter_override=adapter)
         self.registry.load()
 
     def get_model_info(self, selector: LineageSelector) -> Dict[str, Any]:


### PR DESCRIPTION
Implemented support for sql files from MS SQL Server. The manifest.json containes the adapter name 'sqlserver' if the dbt core project has been initialized with the ms sql server adapter. The sqlglot sql parser utilizes the term 'tsql' for this sql dialect. Supporting this dialect is basically a one-liner to match 'sqlserver' to 'tsql'.

The implementation provides two means to provide an adapter match.
* command line argument (CLI) --adapter <adapter-name> this option overrides everything that is dynamically parsed / matched from manifest.json

* matching class that contains a simple dictionary mapping from one name to another, that could be used for future conflicts with adapter names see registry.py

Instead of using the adapter name from the manifest.json file directly, the registry is used to potentially map different adapter names to sqlglot names. The CLI argument overrides any of this mechanism and enforces the adapter name.