### PR TITLE
ci: always install dependencies in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,7 @@ jobs:
         path: .venv
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
-    - name: Update poetry.lock
-      run: poetry lock
-
     - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction
 
     - name: Run unit tests


### PR DESCRIPTION
Remove conditional installation that was causing pytest to be missing
when poetry cache was hit. poetry install will automatically update
lock file if needed.